### PR TITLE
Cue notes away from center

### DIFF
--- a/src/cue_notes_create.lua
+++ b/src/cue_notes_create.lua
@@ -40,6 +40,13 @@ local config = { -- retained and over-written by the user's "settings" file
     window_pos_y        =   false,
 }
 
+local freeze = {
+    none = 0,
+    up = 1,
+    down = 2,
+    away_from_center = 3
+}
+
 local configuration = require("library.configuration")
 local clef = require("library.clef")
 local layer = require("library.layer")
@@ -198,6 +205,7 @@ function choose_destination_staff(source_staff)
         :AddString("Stems: normal")  -- == 0 (normal)
         :AddString("Stems: freeze up")  -- == 1 (up)
         :AddString("Stems: freeze down")  -- == 2 (down)
+        :AddString("Stems: away from center")  -- == 3 (away from center)
         :SetSelectedItem(config.freeze_up_down) -- 0-based index configure value
 
     local function set_check_state(state)
@@ -290,6 +298,19 @@ function fix_text_expressions(region)
     end
 end
 
+function get_away_from_center_up(region)
+    if config.freeze_up_down ~= freeze.away_from_center then return false end
+    local above_midline_net = 0
+    for entry in eachentry(region) do
+        if entry:IsNote() then
+            for note in each(entry) do
+                above_midline_net = above_midline_net + (note:CalcStaffPosition() >= -4 and 1 or -1)
+            end
+        end
+    end
+    return above_midline_net >= 0
+end
+
 function copy_to_destination(source_region, destination_staff)
     local destination_region = finale.FCMusicRegion()
     destination_region:SetRegion(source_region)
@@ -313,6 +334,14 @@ function copy_to_destination(source_region, destination_staff)
             layer.clear(destination_region, layer_number)
         end
     end
+
+    -- swap source_layer with cuenote_layer & fix clef
+    layer.swap(destination_region, config.source_layer, config.cuenote_layer)
+    if not config.copy_clef then
+        clef.restore_default_clef(destination_region.StartMeasure, destination_region.EndMeasure, destination_staff)
+    end
+
+    local away_from_center_up = get_away_from_center_up(destination_region)
 
     -- mute / set to % size / delete articulations? / freeze stems? / delete lyrics?
     for entry in eachentrysaved(destination_region) do
@@ -339,21 +368,44 @@ function copy_to_destination(source_region, destination_staff)
                 end
             end
         end
-        if config.freeze_up_down > 0 then -- frozen stems requested
+        if config.freeze_up_down > freeze.none then -- frozen stems requested
             entry.FreezeStem = true
-            entry.StemUp = (config.freeze_up_down == 1) -- "true" -> upstem, "false" -> downstem
+            local freeze_stem_up = {
+                true,
+                false,
+                away_from_center_up
+            }
+            entry.StemUp = freeze_stem_up[config.freeze_up_down]
         else
             entry.FreezeStem = false
         end
+
+        -- freeze ties and tuplets for "away from center" stems
+        if config.freeze_up_down == freeze.away_from_center then
+            if entry:IsNote() and entry:IsTied() then
+                for note in each(entry) do
+                    if note.Tie then
+                        local tie_mod = finale.FCTieMod(finale.TIEMODTYPE_TIESTART)
+                        tie_mod.TieDirection = away_from_center_up 
+                            and finale.TIEMODDIR_OVER 
+                            or finale.TIEMODDIR_UNDER
+                        tie_mod:SaveAt(note)
+                    end
+                end
+            end
+            if entry.TupletStartFlag then
+                for tuplet in each(entry:CreateTuplets()) do
+                    tuplet.PlacementMode = finale.TUPLETPLACEMENT_STEMSIDE
+                    tuplet:Save()
+                end
+            end
+        end
     end
-    -- swap source_layer with cuenote_layer & fix clef
-    layer.swap(destination_region, config.source_layer, config.cuenote_layer)
-    if not config.copy_clef then
-        clef.restore_default_clef(destination_region.StartMeasure, destination_region.EndMeasure, destination_staff)
-    end
+    
 
     -- delete or amend text expressions
     fix_text_expressions(destination_region)
+
     -- check smart shapes
     if not config.copy_smartshapes or not config.copy_slurs then
         local marks = finale.FCSmartShapeMeasureMarks()
@@ -362,6 +414,23 @@ function copy_to_destination(source_region, destination_staff)
             local shape = m:CreateSmartShape()
             if (shape:IsSlur() and not config.copy_slurs) or (not shape:IsSlur() and not config.copy_smartshapes) then
                 shape:DeleteData()
+            end
+        end
+    elseif config.copy_slurs and config.freeze_up_down == freeze.away_from_center then
+        local marks = finale.FCSmartShapeMeasureMarks()
+        marks:LoadAllForRegion(destination_region, true)
+        for m in each(marks) do
+            local shape = m:CreateSmartShape()
+            if shape:IsSolidSlur() then
+                shape:SetShapeType(away_from_center_up 
+                    and finale.SMARTSHAPE_SLURUP 
+                    or finale.SMARTSHAPE_SLURDOWN
+                )
+            elseif shape:IsDashedSlur() then
+                shape:SetShapeType(away_from_center_up 
+                    and finale.SMARTSHAPE_DASHEDSLURUP 
+                    or finale.SMARTSHAPE_DASHEDSLURDOWN
+                )
             end
         end
     end

--- a/src/cue_notes_create.lua
+++ b/src/cue_notes_create.lua
@@ -416,7 +416,8 @@ function copy_to_destination(source_region, destination_staff)
                 shape:DeleteData()
             end
         end
-    elseif config.copy_slurs and config.freeze_up_down == freeze.away_from_center then
+    end
+    if config.copy_slurs and config.freeze_up_down == freeze.away_from_center then
         local marks = finale.FCSmartShapeMeasureMarks()
         marks:LoadAllForRegion(destination_region, true)
         for m in each(marks) do
@@ -426,11 +427,13 @@ function copy_to_destination(source_region, destination_staff)
                     and finale.SMARTSHAPE_SLURUP 
                     or finale.SMARTSHAPE_SLURDOWN
                 )
+                shape:Save()
             elseif shape:IsDashedSlur() then
                 shape:SetShapeType(away_from_center_up 
                     and finale.SMARTSHAPE_DASHEDSLURUP 
                     or finale.SMARTSHAPE_DASHEDSLURDOWN
                 )
+                shape:Save()
             end
         end
     end

--- a/src/cue_notes_create.lua
+++ b/src/cue_notes_create.lua
@@ -17,8 +17,20 @@ function plugindef()
         Under RGPLua (v0.58+) a new category is created automatically if needed. 
         To use with JWLua you must first create an Expression Category called "Cue Names". 
         ]]
+    finaleplugin.AdditionalMenuOptions = [[
+        Cue Notes Flip Frozen
+    ]]
+    finaleplugin.AdditionalUndoText = [[
+        Cue Notes Flip Frozen
+    ]]
+    finaleplugin.AdditionalPrefixes = [[
+        action = "flip"
+    ]]
+    
     return "Cue Notes Create...", "Cue Notes Create", "Copy as cue notes to another staff"
 end
+
+action = action or "create"
 
 local config = { -- retained and over-written by the user's "settings" file
     copy_articulations  =   false,
@@ -61,6 +73,7 @@ function show_error(error_code)
         empty_region = "Please select a region\nwith some notes in it!",
         no_notes_in_source_layer = "The music selected contains\nno notes in layer " .. config.source_layer,
         first_make_expression_category = "You must first create a new Text Expression Category called \""..config.cue_category_name.."\" containing at least one entry",
+        no_cue_notes = "The region selected contains \nno notes in layer " .. config.cuenote_layer
     }
     local msg = errors[error_code] or "Unknown error condition"
     finenv.UI():AlertNeutral("script: " .. plugindef(), msg)
@@ -311,6 +324,48 @@ function get_away_from_center_up(region)
     return above_midline_net >= 0
 end
 
+function freeze_tuplets_and_ties(entry, up)
+    if entry:IsNote() and entry:IsTied() then
+        for note in each(entry) do
+            if note.Tie then
+                local tie_mod = finale.FCTieMod(finale.TIEMODTYPE_TIESTART)
+                tie_mod.TieDirection = up
+                    and finale.TIEMODDIR_OVER 
+                    or finale.TIEMODDIR_UNDER
+                tie_mod:SaveAt(note)
+            end
+        end
+    end
+
+    if entry.TupletStartFlag then
+        for tuplet in each(entry:CreateTuplets()) do
+            tuplet.PlacementMode = finale.TUPLETPLACEMENT_STEMSIDE
+            tuplet:Save()
+        end
+    end
+end
+
+function freeze_slurs(region, up)
+    local marks = finale.FCSmartShapeMeasureMarks()
+    marks:LoadAllForRegion(region, true)
+    for m in each(marks) do
+        local shape = m:CreateSmartShape()
+        if shape:IsSolidSlur() then
+            shape:SetShapeType(up 
+                and finale.SMARTSHAPE_SLURUP 
+                or finale.SMARTSHAPE_SLURDOWN
+            )
+            shape:Save()
+        elseif shape:IsDashedSlur() then
+            shape:SetShapeType(up 
+                and finale.SMARTSHAPE_DASHEDSLURUP 
+                or finale.SMARTSHAPE_DASHEDSLURDOWN
+            )
+            shape:Save()
+        end
+    end
+end
+
 function copy_to_destination(source_region, destination_staff)
     local destination_region = finale.FCMusicRegion()
     destination_region:SetRegion(source_region)
@@ -382,23 +437,7 @@ function copy_to_destination(source_region, destination_staff)
 
         -- freeze ties and tuplets for "away from center" stems
         if config.freeze_up_down == freeze.away_from_center then
-            if entry:IsNote() and entry:IsTied() then
-                for note in each(entry) do
-                    if note.Tie then
-                        local tie_mod = finale.FCTieMod(finale.TIEMODTYPE_TIESTART)
-                        tie_mod.TieDirection = away_from_center_up 
-                            and finale.TIEMODDIR_OVER 
-                            or finale.TIEMODDIR_UNDER
-                        tie_mod:SaveAt(note)
-                    end
-                end
-            end
-            if entry.TupletStartFlag then
-                for tuplet in each(entry:CreateTuplets()) do
-                    tuplet.PlacementMode = finale.TUPLETPLACEMENT_STEMSIDE
-                    tuplet:Save()
-                end
-            end
+            freeze_tuplets_and_ties(entry, away_from_center_up)            
         end
     end
     
@@ -418,24 +457,7 @@ function copy_to_destination(source_region, destination_staff)
         end
     end
     if config.copy_slurs and config.freeze_up_down == freeze.away_from_center then
-        local marks = finale.FCSmartShapeMeasureMarks()
-        marks:LoadAllForRegion(destination_region, true)
-        for m in each(marks) do
-            local shape = m:CreateSmartShape()
-            if shape:IsSolidSlur() then
-                shape:SetShapeType(away_from_center_up 
-                    and finale.SMARTSHAPE_SLURUP 
-                    or finale.SMARTSHAPE_SLURDOWN
-                )
-                shape:Save()
-            elseif shape:IsDashedSlur() then
-                shape:SetShapeType(away_from_center_up 
-                    and finale.SMARTSHAPE_DASHEDSLURUP 
-                    or finale.SMARTSHAPE_DASHEDSLURDOWN
-                )
-                shape:Save()
-            end
-        end
+        freeze_slurs(destination_region, away_from_center_up)
     end
 
     -- create whole-note rest in rest_layer in each measure
@@ -555,4 +577,39 @@ function create_cue_notes()
     source_region:SetInDocument()
 end
 
-create_cue_notes() -- go and do it already
+function flip_cue_notes()
+    local region = finenv.Region()
+    if not region_contains_notes(region, config.cuenote_layer) then
+        show_error("no_cue_notes")
+        return
+    end
+
+    local zero_based_cue_layer = config.cuenote_layer - 1
+    for staff = region.StartStaff, region.EndStaff do
+        local freeze_up = nil
+        local this_layer = finale.FCNoteEntryLayer(zero_based_cue_layer, staff, region.StartMeasure, region.EndMeasure)
+        this_layer:Load()        
+        for entry in each(this_layer) do
+            if entry:IsNote() and not entry.FreezeStem then goto next_staff end      
+            entry.StemUp = not entry.StemUp
+            if freeze_up == nil then freeze_up = entry.StemUp end
+            freeze_tuplets_and_ties(entry, freeze_up)
+        end
+        this_layer:Save()
+
+        local staff_region = mixin.FCMMusicRegion()
+            :SetRegion(region)
+            :SetStartStaff(staff)
+            :SetEndStaff(staff)
+        freeze_slurs(staff_region, freeze_up)      
+          
+        ::next_staff::
+    end
+end
+
+
+if action == "flip" then
+    flip_cue_notes()
+else
+    create_cue_notes() -- go and do it already
+end

--- a/src/cue_notes_create.lua
+++ b/src/cue_notes_create.lua
@@ -44,7 +44,7 @@ local config = { -- retained and over-written by the user's "settings" file
     source_layer        =   1,     -- layer the cue comes from
     cuenote_layer       =   3,     -- layer the cue ends up
     rest_layer          =   1,     -- layer for default wholenote rest
-    freeze_up_down      =   0,     -- "0" for no stem freezing, "1" for up, "2" for down, "3" for away from center
+    freeze_up_down      =   0,     -- "0" for no stem freezing, "1" for up, "2" for down, "3" for away from middle
     -- if creating a new "Cue Names" category ...
     cue_category_name   =   "Cue Names",
     cue_font_smaller    =   1, -- how many points smaller than the standard technique expression
@@ -56,7 +56,7 @@ local freeze = {
     none = 0,
     up = 1,
     down = 2,
-    away_from_center = 3
+    away_from_middle = 3
 }
 
 local configuration = require("library.configuration")
@@ -218,7 +218,7 @@ function choose_destination_staff(source_staff)
         :AddString("Stems: normal")  -- == 0 (normal)
         :AddString("Stems: freeze up")  -- == 1 (up)
         :AddString("Stems: freeze down")  -- == 2 (down)
-        :AddString("Stems: away from center")  -- == 3 (away from center)
+        :AddString("Stems: away from middle")  -- == 3 (away from middle)
         :SetSelectedItem(config.freeze_up_down) -- 0-based index configure value
 
     local function set_check_state(state)
@@ -311,8 +311,8 @@ function fix_text_expressions(region)
     end
 end
 
-function get_away_from_center_up(region)
-    if config.freeze_up_down ~= freeze.away_from_center then return false end
+function get_away_from_middle_is_up(region)
+    if config.freeze_up_down ~= freeze.away_from_middle then return false end
     local above_midline_net = 0
     for entry in eachentry(region) do
         if entry:IsNote() then
@@ -396,7 +396,7 @@ function copy_to_destination(source_region, destination_staff)
         clef.restore_default_clef(destination_region.StartMeasure, destination_region.EndMeasure, destination_staff)
     end
 
-    local away_from_center_up = get_away_from_center_up(destination_region)
+    local away_from_middle_is_up = get_away_from_middle_is_up(destination_region)
 
     -- mute / set to % size / delete articulations? / freeze stems? / delete lyrics?
     for entry in eachentrysaved(destination_region) do
@@ -428,16 +428,16 @@ function copy_to_destination(source_region, destination_staff)
             local freeze_stem_up = {
                 true,
                 false,
-                away_from_center_up
+                away_from_middle_is_up
             }
             entry.StemUp = freeze_stem_up[config.freeze_up_down]
         else
             entry.FreezeStem = false
         end
 
-        -- freeze ties and tuplets for "away from center" stems
-        if config.freeze_up_down == freeze.away_from_center then
-            freeze_tuplets_and_ties(entry, away_from_center_up)            
+        -- freeze ties and tuplets for "away from middle" stems
+        if config.freeze_up_down == freeze.away_from_middle then
+            freeze_tuplets_and_ties(entry, away_from_middle_is_up)            
         end
     end
     
@@ -456,8 +456,8 @@ function copy_to_destination(source_region, destination_staff)
             end
         end
     end
-    if config.copy_slurs and config.freeze_up_down == freeze.away_from_center then
-        freeze_slurs(destination_region, away_from_center_up)
+    if config.copy_slurs and config.freeze_up_down == freeze.away_from_middle then
+        freeze_slurs(destination_region, away_from_middle_is_up)
     end
 
     -- create whole-note rest in rest_layer in each measure

--- a/src/cue_notes_create.lua
+++ b/src/cue_notes_create.lua
@@ -313,15 +313,15 @@ end
 
 function get_away_from_middle_is_up(region)
     if config.freeze_up_down ~= freeze.away_from_middle then return false end
-    local above_midline_net = 0
+    local total_displacement = 0
     for entry in eachentry(region) do
         if entry:IsNote() then
             for note in each(entry) do
-                above_midline_net = above_midline_net + (note:CalcStaffPosition() >= -4 and 1 or -1)
+                total_displacement = total_displacement + (note:CalcStaffPosition() + 4)                
             end
         end
     end
-    return above_midline_net >= 0
+    return total_displacement >= 0
 end
 
 function freeze_tuplets_and_ties(entry, up)

--- a/src/cue_notes_create.lua
+++ b/src/cue_notes_create.lua
@@ -76,7 +76,7 @@ function show_error(error_code)
         no_cue_notes = "The region selected contains \nno notes in layer " .. config.cuenote_layer
     }
     local msg = errors[error_code] or "Unknown error condition"
-    finenv.UI():AlertNeutral("script: " .. plugindef(), msg)
+    finenv.UI():AlertNeutral(msg, "script: " .. plugindef())
     return -1
 end
 


### PR DESCRIPTION
I've also added the function to flip frozen cue notes. It will look in `config.cuenote_layer` and will flip any cues that have frozen stems (either those that were created with freeze up/down or away from center). My thought is that flipping a cue that didn't have stems frozen in the first place doesn't make much sense.

Note that "away from center" (and "flip") will auto freeze tuplets, ties, and slurs. To my way of thinking freeze up and freeze down should do the same thing -- that is, if I'm freezing stems up, I'm probably going to put the layer 1 rest below the cue, so ties and slurs should all go above rather than under. I haven't made this change -- all existing plugin functionality is untouched -- but if you agree with me it's easy for me to add it.

I also made one small fix of what I think was a bug -- in `show_error` I think you had the message and title params backwards for `AlertNeutral()`. I can back this change out if I was wrong.

Thanks for considering adopting this new functionality.